### PR TITLE
Deciliter and Centiliter were mixed up

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/converters/VolumeConverter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/converters/VolumeConverter.kt
@@ -43,20 +43,20 @@ object VolumeConverter : Converter {
             key = "Liter"
         )
 
-        data object Centiliter : Unit(
-            nameResId = R.string.unit_volume_centiliter,
-            symbolResId = R.string.unit_volume_centiliter_symbol,
-            factor = 0.0001,
-            key = "Centiliter"
-        )
-
         data object Deciliter : Unit(
             nameResId = R.string.unit_volume_deciliter,
             symbolResId = R.string.unit_volume_deciliter_symbol,
-            factor = 0.00001,
+            factor = 0.0001,
             key = "Deciliter"
         )
 
+        data object Centiliter : Unit(
+            nameResId = R.string.unit_volume_centiliter,
+            symbolResId = R.string.unit_volume_centiliter_symbol,
+            factor = 0.00001,
+            key = "Centiliter"
+        )
+        
         data object Milliliter : Unit(
             nameResId = R.string.unit_volume_milliliter,
             symbolResId = R.string.unit_volume_milliliter_symbol,

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/converters/VolumeConverter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/converters/VolumeConverter.kt
@@ -56,7 +56,7 @@ object VolumeConverter : Converter {
             factor = 0.00001,
             key = "Centiliter"
         )
-        
+
         data object Milliliter : Unit(
             nameResId = R.string.unit_volume_milliliter,
             symbolResId = R.string.unit_volume_milliliter_symbol,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Deciliter and Centiliter were mixed up.

1 dl = 0.1 liter ... however the app came up with 0.01 liter


See https://en.wikipedia.org/wiki/Litre#SI_prefixes_applied_to_the_litre for the correct order.


#### Fixes the following issue(s)
- Fixes https://github.com/SimpleMobileTools/Simple-Calculator/issues/343

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calculator/blob/master/CONTRIBUTING.md).
