### PR TITLE
enhancement: clear result on numpad press after a result has been returned.

### DIFF
--- a/app/src/main/kotlin/org/fossify/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/org/fossify/calculator/helpers/CalculatorImpl.kt
@@ -396,6 +396,9 @@ class CalculatorImpl(
         }
 
         if (lastKey == EQUALS) {
+            if (lastOperation != "") {
+                handleReset()
+            }
             lastOperation = EQUALS
         }
 


### PR DESCRIPTION
This results in the user being able to type a new calculation immediately after getting the result of the last calculation instead of just adding more digits to the end of the result.

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- clear result and formula on numpad press after the result of an operation has been returned.

#### Fixes the following issue(s)
- Fixes #41 

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Calculator/blob/master/CONTRIBUTING.md).
