### PR TITLE
Updating French strings

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,7 +60,7 @@
     <string name="unit_volume_pint_imperial">Pinte impériale britannique</string>
     <string name="unit_volume_gill_imperial">Gille impériale britannique</string>
     <string name="unit_volume_fluid_ounce_imperial">Once liquide impériale britannique</string>
-    <string name="unit_mass">Unités de masse</string>
+    <string name="unit_mass">Masse</string>
     <string name="unit_mass_gram">Gramme</string>
     <string name="unit_mass_kilogram">Kilogramme</string>
     <string name="unit_mass_milligram">Milligramme</string>
@@ -73,8 +73,8 @@
     <string name="unit_mass_long_ton">Longue tonne impériale britannique avoirdupois</string>
     <string name="unit_mass_short_ton">Tonne courte coutumière américaine</string>
     <string name="unit_mass_carat_metric">Carat (métrique)</string>
-    <string name="unit_temperature">Unités de température</string>
-    <string name="unit_time">Unités de temps</string>
+    <string name="unit_temperature">Température</string>
+    <string name="unit_time">Temps</string>
     <string name="unit_time_hour">Heure</string>
     <string name="unit_time_second">Seconde</string>
     <string name="unit_time_millisecond">Microseconde</string>


### PR DESCRIPTION
Removes the "Unité de..." before each unit conversion title, as it is already written in the header and makes the important information overflow.

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Update strings

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
<img alt="Screenshot_20250215-171424_Calculator" src="https://github.com/user-attachments/assets/80262291-2610-49b1-a272-df2415cc9d8f" width=199 />

- After:

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calculator/blob/master/CONTRIBUTING.md).
