### PR TITLE
fix: only show plus/minus button for supported units

### DIFF
--- a/app/src/main/kotlin/org/fossify/math/activities/UnitConverterActivity.kt
+++ b/app/src/main/kotlin/org/fossify/math/activities/UnitConverterActivity.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.WindowManager
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
+import org.fossify.commons.extensions.beVisibleIf
 import org.fossify.commons.extensions.getProperTextColor
 import org.fossify.commons.extensions.performHapticFeedback
 import org.fossify.commons.extensions.viewBinding
@@ -21,8 +22,9 @@ import org.fossify.math.helpers.CONVERTER_STATE
 import org.fossify.math.helpers.DOT
 import org.fossify.math.helpers.converters.Converter
 import org.fossify.math.helpers.converters.TemperatureConverter
+import org.fossify.math.views.ConverterView
 
-class UnitConverterActivity : SimpleActivity() {
+class UnitConverterActivity : SimpleActivity(), ConverterView.OnUnitChangedListener {
     companion object {
         const val EXTRA_CONVERTER_ID = "converter_id"
     }
@@ -30,6 +32,12 @@ class UnitConverterActivity : SimpleActivity() {
     private val binding by viewBinding(ActivityUnitConverterBinding::inflate)
     private var vibrateOnButtonPress = true
     private lateinit var converter: Converter
+
+    private val pillDrawable by lazy {
+        ResourcesCompat.getDrawable(
+            resources, org.fossify.commons.R.drawable.pill_background, theme
+        )?.mutate()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         isMaterialActivity = true
@@ -57,9 +65,6 @@ class UnitConverterActivity : SimpleActivity() {
         }
         this.converter = converter
 
-        binding.viewUnitConverter.plusMinusLayout.visibility =
-            if (converter.key == TemperatureConverter.key) View.VISIBLE else View.GONE
-
         binding.viewUnitConverter.btnClear.setVibratingOnClickListener {
             binding.viewUnitConverter.viewConverter.root.deleteCharacter()
         }
@@ -74,6 +79,7 @@ class UnitConverterActivity : SimpleActivity() {
             }
         }
 
+        binding.viewUnitConverter.viewConverter.root.setOnUnitChangedListener(this)
         binding.viewUnitConverter.viewConverter.root.setConverter(converter)
         binding.unitConverterToolbar.setTitle(converter.nameResId)
 
@@ -137,12 +143,7 @@ class UnitConverterActivity : SimpleActivity() {
             }
 
             if (plusMinusLayout.isVisible) {
-                btnPlusMinus.background = ResourcesCompat.getDrawable(
-                    resources,
-                    org.fossify.commons.R.drawable.pill_background,
-                    theme
-                )
-                btnPlusMinus.background?.alpha = MEDIUM_ALPHA_INT
+                updatePlusMinusButton()
             }
         }
     }
@@ -160,6 +161,19 @@ class UnitConverterActivity : SimpleActivity() {
             CONVERTER_STATE,
             binding.viewUnitConverter.viewConverter.root.saveState()
         )
+    }
+
+    override fun onUnitsChanged(topUnit: Converter.Unit?, bottomUnit: Converter.Unit?) {
+        val isTemperatureConverter = converter.key == TemperatureConverter.key
+        val shouldShowNegativeButton =
+            isTemperatureConverter && when (topUnit?.key) {
+                TemperatureConverter.Unit.Kelvin.key,
+                TemperatureConverter.Unit.Rankine.key -> false
+                else -> true
+            }
+
+        binding.viewUnitConverter.plusMinusLayout.beVisibleIf(shouldShowNegativeButton)
+        if (shouldShowNegativeButton) updatePlusMinusButton()
     }
 
     private fun checkHaptic(view: View) {
@@ -196,5 +210,12 @@ class UnitConverterActivity : SimpleActivity() {
             groupingSeparator = groupingSeparator
         )
         binding.viewUnitConverter.btnDecimal.text = decimalSeparator
+    }
+
+    private fun updatePlusMinusButton() {
+        with(binding.viewUnitConverter) {
+            btnPlusMinus.background = pillDrawable
+            btnPlusMinus.background?.alpha = MEDIUM_ALPHA_INT
+        }
     }
 }

--- a/app/src/main/kotlin/org/fossify/math/views/ConverterView.kt
+++ b/app/src/main/kotlin/org/fossify/math/views/ConverterView.kt
@@ -42,6 +42,8 @@ class ConverterView @JvmOverloads constructor(
     private val formatter = NumberFormatHelper(
         decimalSeparator = decimalSeparator, groupingSeparator = groupingSeparator
     )
+    
+    private var unitChangedListener: OnUnitChangedListener? = null
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -74,6 +76,15 @@ class ConverterView @JvmOverloads constructor(
         binding.topUnitText.text = "0"
         updateBottomValue()
         updateUnitLabelsAndSymbols()
+        notifyUnitsChanged()
+    }
+    
+    fun setOnUnitChangedListener(listener: OnUnitChangedListener?) {
+        unitChangedListener = listener
+    }
+    
+    private fun notifyUnitsChanged() {
+        unitChangedListener?.onUnitsChanged(topUnit, bottomUnit)
     }
 
     fun updateColors() {
@@ -114,7 +125,7 @@ class ConverterView @JvmOverloads constructor(
 
     fun deleteCharacter() {
         try {
-            var currentText = binding.topUnitText.text.toString()
+            val currentText = binding.topUnitText.text.toString()
             if (currentText.length == 1) {
                 binding.topUnitText.text = "0"
             } else {
@@ -198,6 +209,7 @@ class ConverterView @JvmOverloads constructor(
         ::topUnit.swapWith(::bottomUnit)
         updateBottomValue()
         updateUnitLabelsAndSymbols()
+        notifyUnitsChanged()
     }
 
     private fun updateUnitLabelsAndSymbols() {
@@ -285,6 +297,7 @@ class ConverterView @JvmOverloads constructor(
                 } else if (unit != propertyToChange.get()) {
                     propertyToChange.set(unit)
                     updateBottomValue()
+                    notifyUnitsChanged()
                 }
                 updateUnitLabelsAndSymbols()
                 context.config.putLastConverterUnits(converter!!, topUnit!!, bottomUnit!!)
@@ -311,6 +324,7 @@ class ConverterView @JvmOverloads constructor(
 
         updateBottomValue()
         updateUnitLabelsAndSymbols()
+        notifyUnitsChanged()
     }
 
     fun toggleNegative() {
@@ -352,5 +366,9 @@ class ConverterView @JvmOverloads constructor(
             }
             else -> value
         }
+    }
+
+    interface OnUnitChangedListener {
+        fun onUnitsChanged(topUnit: Converter.Unit?, bottomUnit: Converter.Unit?)
     }
 }

--- a/app/src/main/res/layout/view_unit_converter.xml
+++ b/app/src/main/res/layout/view_unit_converter.xml
@@ -4,6 +4,7 @@
     android:id="@+id/converter_holder"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
     android:hapticFeedbackEnabled="true"
     android:layoutDirection="ltr"
     android:orientation="vertical"
@@ -15,7 +16,7 @@
         layout="@layout/view_converter"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="1.5"/>
+        android:layout_weight="1.5" />
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Made plus/minus button visibility conditional based on selected temperature unit
- Enabled layout animation

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->
- Not tracked. Just a minor fix/improvement over https://github.com/FossifyOrg/Calculator/pull/49

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.
