### PR TITLE
fix: use proper separator when applying temperature limits

### DIFF
--- a/app/src/main/kotlin/org/fossify/math/views/ConverterView.kt
+++ b/app/src/main/kotlin/org/fossify/math/views/ConverterView.kt
@@ -141,7 +141,7 @@ class ConverterView @JvmOverloads constructor(
 
     fun clear() {
         binding.topUnitText.text = "0"
-        binding.bottomUnitText.text = "0"
+        updateBottomValue()
     }
 
     fun deleteCharacter() {

--- a/app/src/main/kotlin/org/fossify/math/views/ConverterView.kt
+++ b/app/src/main/kotlin/org/fossify/math/views/ConverterView.kt
@@ -381,11 +381,17 @@ class ConverterView @JvmOverloads constructor(
 
         return when (topUnit?.key) {
             TemperatureConverter.Unit.Celsius.key -> {
-                if (numericValue < BigDecimal("-273.15")) "-273.15" else value
+                val minCelsius = BigDecimal("-273.15")
+                if (numericValue < minCelsius) formatter.bigDecimalToString(minCelsius) else value
             }
 
             TemperatureConverter.Unit.Fahrenheit.key -> {
-                if (numericValue < BigDecimal("-459.67")) "-459.67" else value
+                val minFahrenheit = BigDecimal("-459.67")
+                if (numericValue < minFahrenheit) {
+                    formatter.bigDecimalToString(minFahrenheit)
+                } else {
+                    value
+                }
             }
 
             TemperatureConverter.Unit.Kelvin.key,


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Switched to proper separator in `checkTemperatureLimits()`

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
