### PR TITLE
feat: support hardware keyboard input, including numpad keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for hardware keyboard input, including numpad keys ([#134])
 
 ## [1.4.0] - 2026-01-30
 ### Added
@@ -79,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#31]: https://github.com/FossifyOrg/Calculator/issues/31
 [#44]: https://github.com/FossifyOrg/Calculator/issues/44
 [#64]: https://github.com/FossifyOrg/Calculator/issues/64
+[#134]: https://github.com/FossifyOrg/Calculator/issues/134
 [#160]: https://github.com/FossifyOrg/Calculator/issues/160
 [#190]: https://github.com/FossifyOrg/Calculator/issues/190
 [#191]: https://github.com/FossifyOrg/Calculator/issues/191

--- a/app/src/main/kotlin/org/fossify/math/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/math/activities/MainActivity.kt
@@ -3,6 +3,7 @@ package org.fossify.math.activities
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.View
 import android.view.WindowManager
 import androidx.core.content.res.ResourcesCompat
@@ -97,6 +98,53 @@ class MainActivity : SimpleActivity(), Calculator {
         binding.calculatorHolder?.let { updateViewColors(it, getProperTextColor()) }
         setupDecimalButton()
         checkAppOnSDCard()
+    }
+
+    private val keyCodeToButtonId = mapOf(
+        KeyEvent.KEYCODE_0 to R.id.btn_0, KeyEvent.KEYCODE_NUMPAD_0 to R.id.btn_0,
+        KeyEvent.KEYCODE_1 to R.id.btn_1, KeyEvent.KEYCODE_NUMPAD_1 to R.id.btn_1,
+        KeyEvent.KEYCODE_2 to R.id.btn_2, KeyEvent.KEYCODE_NUMPAD_2 to R.id.btn_2,
+        KeyEvent.KEYCODE_3 to R.id.btn_3, KeyEvent.KEYCODE_NUMPAD_3 to R.id.btn_3,
+        KeyEvent.KEYCODE_4 to R.id.btn_4, KeyEvent.KEYCODE_NUMPAD_4 to R.id.btn_4,
+        KeyEvent.KEYCODE_5 to R.id.btn_5, KeyEvent.KEYCODE_NUMPAD_5 to R.id.btn_5,
+        KeyEvent.KEYCODE_6 to R.id.btn_6, KeyEvent.KEYCODE_NUMPAD_6 to R.id.btn_6,
+        KeyEvent.KEYCODE_7 to R.id.btn_7, KeyEvent.KEYCODE_NUMPAD_7 to R.id.btn_7,
+        KeyEvent.KEYCODE_8 to R.id.btn_8, KeyEvent.KEYCODE_NUMPAD_8 to R.id.btn_8,
+        KeyEvent.KEYCODE_9 to R.id.btn_9, KeyEvent.KEYCODE_NUMPAD_9 to R.id.btn_9,
+        KeyEvent.KEYCODE_PERIOD to R.id.btn_decimal,
+        KeyEvent.KEYCODE_COMMA to R.id.btn_decimal,
+        KeyEvent.KEYCODE_NUMPAD_DOT to R.id.btn_decimal,
+    )
+
+    private val keyCodeToOperation = mapOf(
+        KeyEvent.KEYCODE_PLUS to PLUS, KeyEvent.KEYCODE_NUMPAD_ADD to PLUS,
+        KeyEvent.KEYCODE_MINUS to MINUS, KeyEvent.KEYCODE_NUMPAD_SUBTRACT to MINUS,
+        KeyEvent.KEYCODE_STAR to MULTIPLY, KeyEvent.KEYCODE_NUMPAD_MULTIPLY to MULTIPLY,
+        KeyEvent.KEYCODE_SLASH to DIVIDE, KeyEvent.KEYCODE_NUMPAD_DIVIDE to DIVIDE,
+    )
+
+    private val equalsKeyCodes = setOf(
+        KeyEvent.KEYCODE_EQUALS, KeyEvent.KEYCODE_NUMPAD_EQUALS,
+        KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER,
+    )
+
+    private val clearKeyCodes = setOf(KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_FORWARD_DEL)
+
+    private val resetKeyCodes = setOf(KeyEvent.KEYCODE_ESCAPE, KeyEvent.KEYCODE_CLEAR)
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        val buttonId = keyCodeToButtonId[keyCode]
+        val operation = keyCodeToOperation[keyCode]
+        when {
+            buttonId != null -> calc.numpadClicked(buttonId)
+            operation != null -> calc.handleOperation(operation)
+            keyCode in equalsKeyCodes -> calc.handleEquals()
+            keyCode in clearKeyCodes -> calc.handleClear()
+            keyCode in resetKeyCodes -> calc.handleReset()
+            else -> return super.onKeyDown(keyCode, event)
+        }
+
+        return true
     }
 
     override fun onResume() {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement

#### What changed and why
The Calculator had **no hardware-keyboard handling at all** — `MainActivity` only wired the on-screen button click listeners, and the formula/result views are non-editable `AutofitTextView`s (no IME path). So every key event from a physical/numpad keyboard (the case reported in #134, e.g. an 8BitDo/Clicks numpad) was silently dropped, whether top-row `KEYCODE_0..9` or `KEYCODE_NUMPAD_*`.

Fix: add an `onKeyDown` override that maps both the top-row and numpad key codes — digits, `+ − × ÷`, `=`, Enter, decimal, backspace, clear — to the **exact same** `calc.*` calls the on-screen buttons already use (`numpadClicked`, `handleOperation`, `handleEquals`, `handleClear`, `handleReset`). Any unrecognized key falls through to `super.onKeyDown`, so no existing behavior changes.

#### Tests performed
Built `fossDebug`, installed on an **Android 15 (API 35) emulator**, drove input via `adb shell input keyevent`:
- Numpad digits `7 8`, `NUMPAD_ADD`, `2`, `NUMPAD_ENTER` → evaluates correctly.
- `ESC` resets the display to `0`; then `NUMPAD_5`, `NUMPAD_MULTIPLY`, `NUMPAD_3`, `NUMPAD_ENTER` → `5×3 = 15`.
- Top-row digits (`KEYCODE_7/8/9`) enter digits; `KEYCODE_DEL` deletes the last character (backspace).
- Unmapped keys (Back, volume) behave normally.

#### Closes the following issue(s)
- Closes #134

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md`.
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
