### PR TITLE
fix: save percentage calculations to history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Percentage operations are saved to calculation history.
+
 
 ## [1.4.0] - 2026-01-30
 ### Added

--- a/app/src/main/kotlin/org/fossify/math/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/org/fossify/math/helpers/CalculatorImpl.kt
@@ -184,9 +184,12 @@ class CalculatorImpl(
             BigDecimal.ZERO
         }
 
-        showNewFormula("${baseValue.format()}${getSign(lastOperation)}${getSecondValue().format()}%")
-        inputDisplayedFormula = result.format()
-        showNewResult(result.format())
+        val formula = "${baseValue.format()}${getSign(lastOperation)}${getSecondValue().format()}%"
+        val formattedResult = result.format()
+        addToHistory(formula, formattedResult)
+        showNewFormula(formula)
+        inputDisplayedFormula = formattedResult
+        showNewResult(formattedResult)
         baseValue = result
     }
 
@@ -297,14 +300,7 @@ class CalculatorImpl(
 
                 showNewResult(result.format())
                 val newFormula = "${baseValue.format()}$sign${secondValue.format()}"
-                HistoryHelper(context).insertOrUpdateHistoryEntry(
-                    History(
-                        id = null,
-                        formula = newFormula,
-                        result = result.format(),
-                        timestamp = System.currentTimeMillis()
-                    )
-                )
+                addToHistory(newFormula, result.format())
                 showNewFormula(newFormula)
                 inputDisplayedFormula = result.format()
                 baseValue = result
@@ -312,6 +308,17 @@ class CalculatorImpl(
                 context.toast(org.fossify.commons.R.string.unknown_error_occurred)
             }
         }
+    }
+
+    private fun addToHistory(formula: String, result: String) {
+        HistoryHelper(context).insertOrUpdateHistoryEntry(
+            History(
+                id = null,
+                formula = formula,
+                result = result,
+                timestamp = System.currentTimeMillis()
+            )
+        )
     }
 
     private fun calculatePercentage(


### PR DESCRIPTION
#### Type of change(s)

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why

- Percentage operations now save their formula and result through the same history path as normal calculations.
- Reused the history insertion logic to keep both paths consistent.

#### Tests performed

- `./gradlew detekt`
- Compiled the affected production classes in an isolated JVM harness and verified `85 × 25 %` creates one history entry with formula `85×25%` and result `21.25`.

#### Closes the following issue(s)

- Closes #304

#### Checklist

- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.